### PR TITLE
Changed WIDTH_MIN from 130 to 190 for more usable default shell sizes on Windows 7 and Windows 10

### DIFF
--- a/lib/glimmer/swt/shell_proxy.rb
+++ b/lib/glimmer/swt/shell_proxy.rb
@@ -32,7 +32,7 @@ module Glimmer
       include_package 'org.eclipse.swt.widgets'
       include_package 'org.eclipse.swt.layout'
 
-      WIDTH_MIN = 130
+      WIDTH_MIN = 190
       HEIGHT_MIN = 0
 
       attr_reader :opened_before


### PR DESCRIPTION
On Windows 7, a new shell window created with shell() has width WIDTH_MIN, currently set to 130:

![image](https://user-images.githubusercontent.com/437106/135510533-c219f450-f1c9-4cdf-a8c9-41772f24269f.png)

Usually a window can be moved by a click-drag to the left of the minimize button.  But with a minimum width shell there doesn't seem to be anywhere to the left of the minimize button where it's possible to do a click-drag.  For a while I didn't think it was possible to click-drag such a window without first resizing it to be wider.

Then I discovered that clicking very carefully between the minimize and maximize buttons allows a click-drag.  But one has to click within a width of 2 or 3 pixels, so it isn't easy to do, and I suspect many users would not discover this.  It appears one should also be able to carefully click between the maximize and close buttons, but I haven't been able to do this.

Changing WIDTH_MIN to 140 allows a reasonable amount of space to do a click-drag to the left of the minimize button:

![image](https://user-images.githubusercontent.com/437106/135510835-71a505f4-277e-46e8-8da4-b1d648afc510.png)

Trying WIDTH_MIN = 140 on Windows 10 produces this shell:

![image](https://user-images.githubusercontent.com/437106/135510877-e84b3d9b-c642-402f-98ac-ea97e58bad14.png)

This looks odd because the minimize button is peeking out behind the left edge of the tiny icon.  It doesn't seem possible to do a click-drag anywhere in this window.

WIDTH_MIN = 180 results in an area only 2 or 3 pixels wide for click-drag, which is too small to realistically be usable.

WIDTH_MIN = 190 produces:

![image](https://user-images.githubusercontent.com/437106/135510919-0e9cab99-d2fe-414f-b50a-08f4b070dfa9.png)

About half the width between the minimize button and the small icon to its left can be used for click-drag.

I did a very quick test with WIDTH_MIN = 190 on Windows 7, Mac Catalina 10.15.7 and Ubuntu 20.04.2 LTS.  The resulting shells all looked good, and click-drag was fairly easy to do.  If the intention is to have the same WIDTH_MIN value on each platform, the smallest reasonable value is 190 (or maybe 187 or so, but using a multiple of 10 seems nice, and 180 is definitely too small.)